### PR TITLE
Add Locator Locomotion Tool

### DIFF
--- a/io_export_cryblend/desc.py
+++ b/io_export_cryblend/desc.py
@@ -168,6 +168,19 @@ list['range_values'] = """Animation range is stored in custom properties\
 
 list['range_markers'] = """Animation range is on stored animation markers.\
  Markers can directly be set on Timeline Editor to change frame range."""
+
+#------------------------------------------------------------------------------
+# Locator Locomotion:
+#------------------------------------------------------------------------------
+
+list['locator_length'] = """The Locator Locomotion bone length to represented\
+ in 3D view."""
+
+list['locator_root'] = """Skeleton Root Bone: The Locator Locomotion bone\
+ is going to be linked/parented to that bone."""
+
+list['locator_move'] = """Movement Reference Bone: The Locator Locomotion\
+ use that bone to copy movements from selected axis."""
  
 #------------------------------------------------------------------------------
 # Export:


### PR DESCRIPTION
That tool add a locator locomotion bone to selected armature according to CryEngine requirements. 

---
### Properties

**Forward Direction:** The Locator Locomotion bone faced direction.
**Bone Length:** The Locator Locomotion bone length to represented in 3D view.
**Skeleton Root Bone:** The Locator Locomotion bone is going to be linked/parented to that bone. Default value is top parent bone.
**Movement Reference Bone:** The Locator Locomotion use that bone to copy movements from selected axis. Default value is child of top parent bone.

Tool properties can be set via Blender Tool Shelf.
![add_locator_locomotion_panel](https://cloud.githubusercontent.com/assets/12111733/17650098/3bec9f1e-624d-11e6-9935-8c0b49662990.jpg)
