### PR TITLE
Scene first layer fix for bmesh

### DIFF
--- a/io_bcry_exporter/export.py
+++ b/io_bcry_exporter/export.py
@@ -435,7 +435,7 @@ class CrytekDaeExporter:
         parent_element.appendChild(libgeo)
         for group in utils.get_mesh_export_nodes(self._config.export_selected_nodes):
             for object_ in group.objects:
-                bmesh_, layer_state = utils.get_bmesh(object_)
+                bmesh_, layer_state, scene_layer = utils.get_bmesh(object_)
                 geometry_node = self._doc.createElement("geometry")
                 geometry_name = utils.get_geometry_name(group, object_)
                 geometry_node.setAttribute("id", geometry_name)
@@ -478,7 +478,7 @@ class CrytekDaeExporter:
                 geometry_node.appendChild(mesh_node)
                 libgeo.appendChild(geometry_node)
 
-                utils.clear_bmesh(object_, layer_state)
+                utils.clear_bmesh(object_, layer_state, scene_layer)
                 cbPrint(
                     '"{}" object has been processed for "{}" node.'.format(
                         object_.name, group.name))

--- a/io_bcry_exporter/utils.py
+++ b/io_bcry_exporter/utils.py
@@ -139,9 +139,12 @@ def get_bmesh(object_):
     # Unfortunately Blender goes in edit mode just objects
     # in which first layer with bpy.ops.object.mode_set(mode='EDIT')
     # So we must temporarily activate first layer for objects which it is not 
-    # already in first layer.
+    # already in first layer. Also scene first layer must be active.
     # That lacking related with Blender, if it will fix in future that 
     # code will be clean.
+
+    scene_first_layer = bpy.context.scene.layers[0]
+    bpy.context.scene.layers[0] = True
 
     layer_state = not object_.layers[0]
     if layer_state:
@@ -149,11 +152,13 @@ def get_bmesh(object_):
 
     bpy.ops.object.mode_set(mode='EDIT')
 
-    return bmesh.from_edit_mesh(object_.data), layer_state
+    return bmesh.from_edit_mesh(object_.data), layer_state, scene_first_layer
 
 
-def clear_bmesh(object_, layer_state):
+def clear_bmesh(object_, layer_state, scene_first_layer):
     bpy.ops.object.mode_set(mode='OBJECT')
+
+    bpy.context.scene.layers[0] = scene_first_layer
 
     if layer_state:
         object_.layers[0] = False


### PR DESCRIPTION
BMesh run in just edit mode and edit mode run only in first layer therefore first layer must be activate is not already.

That code activate first scene layer if is not already activated, then restore its initial statue.
