### PR TITLE
Triangulated Geometry #18

### DIFF
--- a/io_bcry_exporter/utils.py
+++ b/io_bcry_exporter/utils.py
@@ -132,6 +132,41 @@ def get_geometry_name(group, object_):
     return geometry_name
 
 
+def duplicate_object(object_):
+    deselect_all()
+    set_active(object_)
+    object_.select = True
+    bpy.ops.object.duplicate()
+    return bpy.context.active_object
+
+
+def get_triangulated_bmesh(object_):
+    set_active(object_)
+
+    # bmesh may be gotten only in edit mode for active object.
+    # Unfortunately Blender goes in edit mode just objects
+    # in which first layer with bpy.ops.object.mode_set(mode='EDIT')
+    # So we must temporarily activate first layer for objects which it is not 
+    # already in first layer. Also scene first layer must be active.
+    # That lacking related with Blender, if it will fix in future that 
+    # code will be clean.
+
+    scene_first_layer = bpy.context.scene.layers[0]
+    bpy.context.scene.layers[0] = True
+
+    layer_state = not object_.layers[0]
+    if layer_state:
+        object_.layers[0] = True
+
+    
+    bpy.ops.object.mode_set(mode='EDIT')
+    
+    bmesh_ = bmesh.from_edit_mesh(object_.data)
+    bmesh.ops.triangulate(bmesh_, faces=bmesh_.faces)
+
+    return bmesh_, layer_state, scene_first_layer
+
+
 def get_bmesh(object_):
     set_active(object_)
 


### PR DESCRIPTION
- BCry Exporter write geometry with polygon form, we must change that triangle form.
- Write poly list must be converted to write triangle list.

Note: Tessfaces have no connection with bmesh, so tessfaces can not be used with bmeshes for now.
Therefore we must use triangulated geometry for normals and uvs, which in that situation normal and uv array extended. We should track of bmesh tessface support in the future version of Blender.
