### PR TITLE
VCloth V2 Base #37

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -2151,6 +2151,11 @@ class Export(bpy.types.Operator, ExportHelper):
         description="Use custom normals.",
         default=False,
     )
+    vcloth_pre_process = BoolProperty(
+        name="VCloth Pre-Process",
+        description="Export skin as simulating mesh for VCloth V2.",
+        default=False,
+    )
     do_materials = BoolProperty(
         name="Do Materials",
         description="Create MTL files for materials.",
@@ -2216,6 +2221,7 @@ class Export(bpy.types.Operator, ExportHelper):
                 'export_selected_nodes',
                 'apply_modifiers',
                 'custom_normals',
+                'vcloth_pre_process',
                 'do_materials',
                 'do_textures',
                 'make_chrparams',
@@ -2279,6 +2285,7 @@ class Export(bpy.types.Operator, ExportHelper):
         box.prop(self, "export_selected_nodes")
         box.prop(self, "apply_modifiers")
         box.prop(self, "custom_normals")
+        box.prop(self, "vcloth_pre_process")
 
         box = col.box()
         box.label("Material & Texture", icon="TEXTURE")

--- a/io_bcry_exporter/export.py
+++ b/io_bcry_exporter/export.py
@@ -1048,6 +1048,11 @@ class CrytekDaeExporter:
 
             prop = self._doc.createTextNode("UseCustomNormals")
             properties.appendChild(prop)
+
+            if self._config.vcloth_pre_process and node_type == 'skin':
+                prop = self._doc.createTextNode("VClothPreProcess")
+                properties.appendChild(prop)
+
             prop = self._doc.createTextNode("CustomExportPath=")
             properties.appendChild(prop)
         else:


### PR DESCRIPTION
Add VCloth V2 exporting support to **BCry Exporter**.
- Create a new checkbox named **VCloth Pre-Process** at General Export Panel.

![vcloth pre-process](https://cloud.githubusercontent.com/assets/12111733/18871346/a1c0891c-84bd-11e6-9335-cbd787f5443d.jpg)

[VCloth V2](http://docs.cryengine.com/display/CEMANUAL/VCloth+2.0)
[VCloth V2 Exporting](http://docs.cryengine.com/display/CEMANUAL/How+To+-+Export+VCloth+from+Maya+to+CRYENGINE)

**Note:** VCloth skin must be exported alone. One can use **Export Only Selected Nodes** Tool at General Export Panel.
