### PR TITLE
Export Node Prediction

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -208,7 +208,24 @@ class AddCryExportNode(bpy.types.Operator):
 
     def __init__(self):
         bpy.ops.object.mode_set(mode='OBJECT')
-        node_name = bpy.context.active_object.name
+        object_ = bpy.context.active_object
+        self.node_name = object_.name
+        self.node_type = 'cgf'
+
+        if object_.type != 'MESH':
+            self.report(
+                {'ERROR'},
+                "Selected object is not a mesh! Please select a mesh object.")
+            return {'FINISHED'}
+
+        if object_.parent and object_.parent.type == 'ARMATURE':
+            if len(object_.data.vertices) <= 4:
+                self.node_type = 'chr'
+                self.node_name = object_.parent.name
+            else:
+                self.node_type = 'skin'
+        elif object_.animation_data:
+            self.node_type = 'cga'
 
     def execute(self, context):
         if bpy.context.selected_objects:


### PR DESCRIPTION
**Add Export Node** tool must be improved.
- Selected object name must be automatically typed to name text box.
- Also **Add Export Node** tool must predict node type. **(cgf, cga, chr, skin)**

![add_node_panel](https://cloud.githubusercontent.com/assets/12111733/19315593/f7b4e328-90a6-11e6-8c98-97c11cfe8acf.jpg)
![add_export_node_panel_cga](https://cloud.githubusercontent.com/assets/12111733/19315598/fbbe2542-90a6-11e6-897f-badadb91124e.jpg)
![add_export_node_panel_skin](https://cloud.githubusercontent.com/assets/12111733/19315600/fdf2b198-90a6-11e6-84ae-c14742f17735.jpg)

---
- If object is a mesh and have a animation clip set default type to **CGA**.
- If object is a mesh and weighted to a skeleton and mesh have vertex high of 4 then assign default type to **SKIN**.
- If object is a mesh and weighted to a skeleton and mesh have vertex below of 5 then assign default type to **CHR**.
- Elsewhere assign default type to **CGF**.
