### PR TITLE
Bone Axis Orientations

### DIFF
--- a/io_bcry_exporter/export.py
+++ b/io_bcry_exporter/export.py
@@ -456,13 +456,10 @@ class CrytekDaeExporter:
 
         bones = utils.get_bones(armature)
         bone_matrices = []
-        for bone in bones:
-            fakebone = utils.get_fakebone(bone.name)
-            if fakebone is None:
-                return
-            matrix_local = copy.deepcopy(fakebone.matrix_local)
-            utils.negate_z_axis_of_matrix(matrix_local)
-            bone_matrices.extend(utils.matrix_to_array(matrix_local))
+        for bone in armature.pose.bones:
+
+            bone_matrix = utils.transform_bone_matrix(bone)
+            bone_matrices.extend(utils.matrix_to_array(bone_matrix))
 
         id_ = "{!s}_{!s}-matrices".format(armature.name, object_.name)
         source = utils.write_source(id_, "float4x4", bone_matrices, [])
@@ -726,14 +723,14 @@ class CrytekDaeExporter:
         return trans
 
     def _create_rotation_node(self, object_):
-        rotx = self._write_rotation(
-            "X", "1 0 0 {:f}", object_.rotation_euler[0])
-        roty = self._write_rotation(
-            "Y", "0 1 0 {:f}", object_.rotation_euler[1])
         rotz = self._write_rotation(
-            "Z", "0 0 1 {:f}", object_.rotation_euler[2])
+            "z", "0 0 1 {:f}", object_.rotation_euler[2])
+        roty = self._write_rotation(
+            "y", "0 1 0 {:f}", object_.rotation_euler[1])
+        rotx = self._write_rotation(
+            "x", "1 0 0 {:f}", object_.rotation_euler[0])
 
-        return rotx, roty, rotz
+        return rotz, roty, rotx
 
     def _write_rotation(self, axis, textFormat, rotation):
         rot = self._doc.createElement("rotate")


### PR DESCRIPTION
**Cryblend** could not export to bone axis orientations for skeletons. Instead, it export all bones as global world locations without any rotation. So rotation informations were (0, 0, 0).

We must export bone orientations with their orientated locations.

**Blender pose bone matrices:**
Blender pose bone matrices store bone rotations and global locations. We must export to **DAE (to RC.exe)**  the locations as orientated locations. Therefore, firstly, we must create a transformation matrix to convert world locations to orientated locations. Then we can combine rotation and new orientated location in a new matrix. Finally we can export that new matrix.

**CryEngine Player SDK has X-Axis bone orientation as primary:**
To use CryEngine SDK animations we must work with X-Axis bone orientation. Unfortunately, Blender only works with Y-Axis bone orientations. To solve that problem, we can again create a transformation matrix to change bone orientations to X-Axis from Y-Axis at export time. When we do that type axis changing, as well we have to change a axis to a negative own its. I am going to use Z-Axis for that. So, in Blender Z-Axis changes to -Z-Axis for **DAE**.

**Combine two matrices:**
We can break down that two problem in one stage with one transformation matrix.

**Animations:**
That rules valid for **CHR** and **SKIN** files, so what about animations? Axis changing (Y to X) requires a bit more working for animations.
