### PR TITLE
VCloth Fix Export Animations

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -2798,6 +2798,7 @@ class ExportAnimations(bpy.types.Operator, ExportHelper):
     merge_all_nodes = True
     generate_materials = False
     make_layer = False
+    vcloth_pre_process = False
 
     class Config:
 
@@ -2805,6 +2806,7 @@ class ExportAnimations(bpy.types.Operator, ExportHelper):
             attributes = (
                 'filepath',
                 'merge_all_nodes',
+                'vcloth_pre_process',
                 'generate_materials',
                 'export_for_lumberyard',
                 'make_layer',


### PR DESCRIPTION
**VCloth Fix**
- **vcloth_pre_process** configuration has been added to **ExportAnimations** class, otherwise **ExportAnimations** tool could not pass below control in **rc.py**

```
            if self.__config.vcloth_pre_process:
                rc_params.append("/wait=0 /forceVCloth")
```
