### PR TITLE
Default Texture

### DIFF
--- a/io_bcry_exporter/material_utils.py
+++ b/io_bcry_exporter/material_utils.py
@@ -160,11 +160,12 @@ def add_textures(_doc, material, material_node, _config):
         texture_node.setAttribute("File", path)
         textures_node.appendChild(texture_node)
     else:
-        texture_node = _doc.createElement('Texture')
-        texture_node.setAttribute("Map", "Diffuse")
-        path = ""
-        texture_node.setAttribute("File", path)
-        textures_node.appendChild(texture_node)
+        if "physProxyNoDraw" != get_material_physic(material.name):
+            texture_node = _doc.createElement('Texture')
+            texture_node.setAttribute("Map", "Diffuse")
+            path = "textures/defaults/white.dds"
+            texture_node.setAttribute("File", path)
+            textures_node.appendChild(texture_node)
     if specular:
         texture_node = _doc.createElement('Texture')
         texture_node.setAttribute("Map", "Specular")


### PR DESCRIPTION
If blender material has no a diffuse texture (intended to use directly colors), **Generate Material** tool assigns default white texture for diffuse.

Default White Texture path: **textures/defaults/white.dds**

**Note:** If material is **physProxyNoDraw** then diffuse texture is going to be empty.
