### PR TITLE
Fix/Zero Division Error

### DIFF
--- a/io_bcry_exporter/utils.py
+++ b/io_bcry_exporter/utils.py
@@ -297,7 +297,8 @@ def get_normal_array(bmesh_, use_edge_angle, use_edge_sharp, split_angle):
                 for vertex_normal in v_normals:
                     area_sum += vertex_normal[1]
                 for vertex_normal in v_normals:
-                    smooth_normal += vertex_normal[0] * (vertex_normal[1] / area_sum)
+                    if area_sum:
+                        smooth_normal += vertex_normal[0] * (vertex_normal[1] / area_sum)
                 float_normals.extend(smooth_normal.normalized())
 
     return float_normals


### PR DESCRIPTION
If mesh has zero area face, smooth normals area calculation #46 generate a **ZeroDivisionError** at **get_normal_array** function.

![zero_division_error](https://cloud.githubusercontent.com/assets/12111733/19592971/f193b05a-9786-11e6-8d23-f199a5c3ff6e.jpg)
- New area_sum control has been added.
