### PR TITLE
Fix/Animation with skin node

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -2739,6 +2739,8 @@ class Export(bpy.types.Operator, ExportHelper):
         default=False,
     )
 
+    is_animation_process = False
+
     class Config:
 
         def __init__(self, config):
@@ -2759,7 +2761,8 @@ class Export(bpy.types.Operator, ExportHelper):
                 'disable_rc',
                 'save_dae',
                 'save_tiffs',
-                'run_in_profiler'
+                'run_in_profiler',
+                'is_animation_process'
             )
 
             for attribute in attributes:
@@ -2875,6 +2878,7 @@ class ExportAnimations(bpy.types.Operator, ExportHelper):
     generate_materials = False
     make_layer = False
     vcloth_pre_process = False
+    is_animation_process = True
 
     class Config:
 
@@ -2885,6 +2889,7 @@ class ExportAnimations(bpy.types.Operator, ExportHelper):
                 'vcloth_pre_process',
                 'generate_materials',
                 'export_for_lumberyard',
+                'is_animation_process',
                 'make_layer',
                 'disable_rc',
                 'save_dae',

--- a/io_bcry_exporter/rc.py
+++ b/io_bcry_exporter/rc.py
@@ -67,8 +67,11 @@ class _DAEConverter:
 
             if rc_process is not None:
                 rc_process.wait()
-                self.__recompile(dae_path)
-                self.__rename_anm_files(dae_path)
+
+                if not self.__config.is_animation_process:
+                    self.__recompile(dae_path)
+                else:
+                    self.__rename_anm_files(dae_path)
 
         if self.__config.make_layer:
             lyr_contents = self.__make_layer()


### PR DESCRIPTION
If your skeleton animation project have **skin** or **chr** nodes, then rc.py file tries **recompile** (second compile) for skin and chr nodes, even if you want to export animations, finally rc.exe generates errors for unfounded skin and chr files.

That is unwanted situation. if user use Export Animation tool **rc.py** skip recompile (second compile) stage, even if there are skin or chr nodes.

---

**is_animation** configuration variable has been added both for **Export** and **ExportAnimations** class.
