### PR TITLE
Find Weightless Window

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -1739,18 +1739,43 @@ it's mesh before running this.'''
 
 
 class FindWeightless(bpy.types.Operator):
-    '''Select the object in object mode with nothing in its mesh selected \
-before running this'''
+    '''Finds out unassigned vertices to any bone.'''
     bl_label = "Find Weightless Vertices"
     bl_idname = "mesh.find_weightless"
 
-    # Minimum net weight to be considered non-weightless
     weight_epsilon = 0.0001
 
-    # Weightless: a vertex not belonging to any groups or with a net weight of
-    # 0
+    message = ""
+    vert_count = 0
+
     def execute(self, context):
+        return {"FINISHED"}
+
+    def draw(self, context):
+        layout = self.layout
+        col = layout.column()
+        col.label(self.message)
+        col.separator()
+        
+        if self.vert_count:
+            col.separator()
+            col.operator("view3d.view_selected", text="Focus")
+            col.separator()
+
+    def __init__(self):
+        self.vert_count = 0
+
+        if bpy.context.active_object is None or bpy.context.active_object.type != "MESH":
+            self.report({'ERROR'}, "Please select a mesh in OBJECT mode.")
+            return None
+
         object_ = bpy.context.active_object
+        if object_.parent == None or object_.parent.type != 'ARMATURE':
+            self.report({'ERROR'}, "Please select a mesh in OBJECT mode.")
+            return None
+
+        armature = object_.parent
+
         bpy.ops.object.mode_set(mode="EDIT")
         bpy.ops.mesh.select_all(action="DESELECT")
         bpy.ops.object.mode_set(mode="OBJECT")
@@ -1758,6 +1783,7 @@ before running this'''
             for v in object_.data.vertices:
                 if (not v.groups):
                     v.select = True
+                    self.vert_count += 1
                 else:
                     weight = 0
                     for g in v.groups:
@@ -1767,15 +1793,23 @@ before running this'''
                     if (weight < self.weight_epsilon):
                         v.select = True
         object_.data.update()
-        bpy.ops.object.mode_set(mode="EDIT")
-        return {"FINISHED"}
+
+        if self.vert_count == 0:
+            self.message = "Selected mesh has no any weightless vertex."
+        else:
+            self.message = "Selected mesh has {} weightless vertices.".format(self.vert_count)
+            bpy.ops.object.mode_set(mode="EDIT")
 
     def invoke(self, context, event):
         if context.object is None or context.object.type != "MESH":
-            self.report({'ERROR'}, "Select a mesh in OBJECT mode.")
+            self.report({'ERROR'}, "Please select a mesh in OBJECT mode.")
+            return {'FINISHED'}
+        object_ = context.object
+        if object_.parent == None or object_.parent.type != 'ARMATURE':
+            self.report({'ERROR'}, "Please select a mesh in OBJECT mode.")
             return {'FINISHED'}
 
-        return self.execute(context)
+        return context.window_manager.invoke_props_dialog(self)
 
 
 class RemoveAllWeight(bpy.types.Operator):


### PR DESCRIPTION
Find weightless tool must be improved.
### Improvement
- Now tool considers weight ratio for just armatured skeleton bones.
### New Features
- New interactive properties window has been added.
  - That window now shows weightless vertex count.
  - New **Focus** button has been added to focus weightless vertices.
  - If there is no any weightless vertex then show this with a message, and stay at **Object Mode**.

---

**Weightless Vertices:**
![find_weightless_focus](https://cloud.githubusercontent.com/assets/12111733/19595904/b7bc78a4-9794-11e6-8214-fe1076d763e9.jpg)

---

**There is no any Weightless Vertex:**
![find_weightless_no](https://cloud.githubusercontent.com/assets/12111733/19595896/b36382ca-9794-11e6-86ed-0e6907fb5e0e.jpg)

---
