### PR TITLE
Armature Writing Enhancements

### DIFF
--- a/io_bcry_exporter/utils.py
+++ b/io_bcry_exporter/utils.py
@@ -726,13 +726,6 @@ def get_node_type(node):
     return node_components[-1]
 
 
-def get_armature_node(object_):
-    ALLOWED_NODE_TYPES = ("cga", "anm", "chr", "skin", "i_caf")
-    for group in object_.users_group:
-        if get_node_type(group) in ALLOWED_NODE_TYPES:
-            return group
-
-
 def is_visual_scene_node_writed(object_, group):
     if is_bone_geometry(object_):
         return False


### PR DESCRIPTION
Armature writing needs a few improvements to enhance exporting capability for have SKIN and CHR nodes project.
- Now, **Library Controller** has been written only for **SKIN** and **CHR** nodes.
- Removed **utils.get_armature_node** function and group directly is gotten from parent functions.
- Now, **_write_bone_list** only is called for **SKIN and __CHR** nodes.
- Added a check statement **node_type** for **create_instance** function and is allowed only **SKIN** and **CHR** nodes.
