### PR TITLE
Default Physic to None

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -757,7 +757,7 @@ class SetMaterialNames(bpy.types.Operator):
             ("physObstruct", "Obstruct", desc.list['physObstruct']),
             ("physNone", "None", desc.list['physNone'])
         ),
-        default="physDefault")
+        default="physNone")
 
     just_rephysic = BoolProperty(
         name="Only Physic",
@@ -869,7 +869,7 @@ class AddMaterial(bpy.types.Operator):
             ("physObstruct", "Obstruct", list['physObstruct']),
             ("physNone", "None", list['physNone']),
         ),
-        default="physDefault",
+        default="physNone",
     )
 
     def execute(self, context):

--- a/io_bcry_exporter/material_utils.py
+++ b/io_bcry_exporter/material_utils.py
@@ -362,7 +362,7 @@ def get_material_parts(node, material):
     group = node
     index = 0
     name = material
-    physics = "physDefault"
+    physics = "physNone"
 
     if count == 1:
         # name
@@ -391,7 +391,7 @@ def get_material_parts(node, material):
 
     name = utils.replace_invalid_rc_characters(name)
     if physics not in VALID_PHYSICS:
-        physics = "physDefault"
+        physics = "physNone"
 
     return group, index, name, physics
 
@@ -447,7 +447,7 @@ def get_material_physic(material_name):
     if index != -1:
         return material_name[index + 2:]
 
-    return "physDefault"
+    return "physNone"
 
 
 def set_material_physic(self, context, phys_name):


### PR DESCRIPTION
Currently default physical proxy type is **default**. That sometimes generate high polygon physic problem for meshes those high polygon count when use auto materials. To solve that default material type can be changed to **none**.
