### PR TITLE
Multiple Cycles Texture

### DIFF
--- a/io_bcry_exporter/material_utils.py
+++ b/io_bcry_exporter/material_utils.py
@@ -213,7 +213,8 @@ def get_diffuse_texture(material):
         if bpy.context.scene.render.engine == 'CYCLES':
             for node in material.node_tree.nodes:
                 if node.type == 'TEX_IMAGE':
-                    if node.name in ['Image Texture', 'Diffuse']:
+                    if node.name == 'Image Texture' or \
+                                    node.name.lower().find('diffuse') != -1:
                         image = node.image
                         if is_valid_image(image):
                             return image
@@ -235,7 +236,7 @@ def get_specular_texture(material):
         if bpy.context.scene.render.engine == 'CYCLES':
             for node in material.node_tree.nodes:
                 if node.type == 'TEX_IMAGE':
-                    if node.name == 'Specular':
+                    if node.name.lower().find('specular') != -1:
                         image = node.image
                         if is_valid_image(image):
                             return image
@@ -257,7 +258,7 @@ def get_normal_texture(material):
         if bpy.context.scene.render.engine == 'CYCLES':
             for node in material.node_tree.nodes:
                 if node.type == 'TEX_IMAGE':
-                    if node.name == 'Normal':
+                    if node.name.lower().find('normal') != -1:
                         image = node.image
                         if is_valid_image(image):
                             return image


### PR DESCRIPTION
To export textures for Cycles Nodes, BCRY Exporter uses node names.
- **Diffuse**
- **Specular**
- **Normal**

---
- Now, a Texture Node can be have multiple names to use same texture both for Diffuse and Specular.
  Example:
  **Diffuse - Specular**.

![node_editor_multiple_texture_tick](https://cloud.githubusercontent.com/assets/12111733/19611829/3a84a0ac-97ec-11e6-9594-10bd45b3f54d.jpg)
