### PR TITLE
Select Game Directory Fix

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -152,7 +152,9 @@ for textures in .mtl file.'''
 
     def process(self, filepath):
         if not os.path.isdir(filepath):
-            raise exceptions.NoGameDirectorySelected
+            filepath = os.path.dirname(filepath)
+            if not os.path.isdir(filepath):
+                raise Exception("Directory is invalid!")
 
         Configuration.game_dir = filepath
         bcPrint("Game directory: {!r}.".format(


### PR DESCRIPTION
Sometimes users can be forget a text at **Blender ExportHelper**, in that case **Select Game Directory** tool raised **NoGameDirectory** error. To solve that:
- Now, we removes forgotten text, if it is not a directory.
- When the directory is invalid, raise a Exception with message **Directory is Invalid!**

![selectgamedirectoryfix](https://cloud.githubusercontent.com/assets/12111733/19626217/0bde51cc-9935-11e6-8cd2-dd9754b7e600.jpg)
