### PR TITLE
Blend Layer #98

### DIFF
--- a/io_bcry_exporter/export.py
+++ b/io_bcry_exporter/export.py
@@ -303,11 +303,19 @@ class CrytekDaeExporter:
         float_colors = []
         alpha_found = False
 
-        color_layer = bmesh_.loops.layers.color.active
+        active_layer = bmesh_.loops.layers.color.active
         if object_.data.vertex_colors:
-            for vert in bmesh_.verts:
-                loop = vert.link_loops[0]
-                float_colors.extend(loop[color_layer])
+            if active_layer.name.lower() == 'alpha':
+                alpha_found = True
+                for vert in bmesh_.verts:
+                    loop = vert.link_loops[0]
+                    color = loop[active_layer]
+                    alpha_color = (color[0] + color[1] + color[2]) / 3.0
+                    float_colors.extend([1.0, 1.0, 1.0, alpha_color])
+            else:
+                for vert in bmesh_.verts:
+                    loop = vert.link_loops[0]
+                    float_colors.extend(loop[active_layer])
 
         if float_colors:
             id_ = "{!s}-vcol".format(geometry_name)


### PR DESCRIPTION
**Blender Layer** support.

As default, **Blender** doesn't have alpha channel for vertex colors which used blend layers at **CryEngine**.

We can add a vertex color channel named **Alpha** for that.

![vertex_colors_alpha](https://cloud.githubusercontent.com/assets/12111733/21508231/0c350388-cc88-11e6-9f77-44d4c18ba91f.jpg)

**Note**: BCRY only export active channel, so there are one more color layer, you have to activate  alpha channel.


[BCRY Exporter Documentation](http://bcry.afcstudio.org/documents/blend-layer/)
[CryEngine Documentation](http://docs.cryengine.com/display/SDKDOC2/Blend+Layer)