### PR TITLE
Parent/Child Relations #105

### DIFF
--- a/io_bcry_exporter/utils.py
+++ b/io_bcry_exporter/utils.py
@@ -748,6 +748,24 @@ def is_visual_scene_node_writed(object_, group):
     return True
 
 
+def is_there_a_parent_releation(object_, group):
+    while object_.parent:
+        print(object_.parent.name)
+        if is_object_in_group(object_.parent, group) and object_.parent.type == 'MESH':
+            return True
+        else:
+            return is_there_a_parent_releation(object_.parent, group)
+
+    return False
+
+
+def is_object_in_group(object_, group):
+    for obj in group.objects:
+        if object_.name == obj.name:
+            return True
+
+    return False
+
 #------------------------------------------------------------------------------
 # Fakebones:
 #------------------------------------------------------------------------------


### PR DESCRIPTION
- Object parent/child relations can be used by CGAs which have multiple mesh in one node; for CGA animations per node have to be consist one root mesh.
- Object parent/child relations also are needed for vehicle structures.

__BCRY__ now exports child object with relations, if child object is in same node with parent.
If child object is not in a node then it's overlooked.