### PR TITLE
Dummy Exporting #107

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -214,7 +214,7 @@ class AddCryExportNode(bpy.types.Operator):
         self.node_name = object_.name
         self.node_type = 'cgf'
 
-        if object_.type != 'MESH':
+        if object_.type not in ('MESH', 'EMPTY'):
             self.report(
                 {'ERROR'},
                 "Selected object is not a mesh! Please select a mesh object.")

--- a/io_bcry_exporter/utils.py
+++ b/io_bcry_exporter/utils.py
@@ -766,6 +766,11 @@ def is_object_in_group(object_, group):
 
     return False
 
+
+def is_dummy(object_):
+    return object_.type == 'EMPTY'
+
+
 #------------------------------------------------------------------------------
 # Fakebones:
 #------------------------------------------------------------------------------
@@ -1315,9 +1320,16 @@ def remove_unused_meshes():
 
 
 def get_bounding_box(object_):
-    box = object_.bound_box
-    vmin = Vector([box[0][0], box[0][1], box[0][2]])
-    vmax = Vector([box[6][0], box[6][1], box[6][2]])
+    vmin = Vector()
+    vmax = Vector()
+    if object_.type == 'EMPTY':
+        k = object_.empty_draw_size
+        vmax = Vector((k, k, k))
+        vmin = Vector((-k, -k, -k))
+    elif object_.type == 'MESH':
+        box = object_.bound_box
+        vmin = Vector([box[0][0], box[0][1], box[0][2]])
+        vmax = Vector([box[6][0], box[6][1], box[6][2]])
 
     return vmin[0], vmin[1], vmin[2], vmax[0], vmax[1], vmax[2]
 


### PR DESCRIPTION
BCRY Export empty objects are exported dummy object at bcry export nodes.

- Bounding box informations are gotten empty draw size.
- Bounding box positions are stored as local values in dummy object visual nodes.
- Dummy objects mustn't have scale informations.
- Now dummy objects can be added to bcry nodes.