### PR TITLE
Generate Material Improvement #108

### DIFF
--- a/io_bcry_exporter/export_materials.py
+++ b/io_bcry_exporter/export_materials.py
@@ -44,10 +44,10 @@ class CrytekMaterialExporter:
 
     def get_materials_for_object(self, object_):
         materials = OrderedDict()
-        for material, materialname in self._materials.items():
+        for material_name, material in self._materials.items():
             for object_material in object_.data.materials:
                 if material.name == object_material.name:
-                    materials[material] = materialname
+                    materials[material] = material_name
 
         return materials
 
@@ -87,17 +87,17 @@ class CrytekMaterialExporter:
 #------------------------------------------------------------------------------
 
     def export_library_effects(self, library_effects):
-        for material, materialname in self._materials.items():
+        for material_name, material in self._materials.items():
             self._export_library_effects_material(
-                material, materialname, library_effects)
+                material, material_name, library_effects)
 
     def _export_library_effects_material(
-            self, material, materialname, library_effects):
+            self, material, material_name, library_effects):
 
         images = material_utils.get_textures(material)
 
         effect_node = self._doc.createElement("effect")
-        effect_node.setAttribute("id", "{}_fx".format(materialname))
+        effect_node.setAttribute("id", "{}_fx".format(material_name))
         profile_node = self._doc.createElement("profile_COMMON")
         self._write_surface_and_sampler(images, profile_node)
 
@@ -222,10 +222,10 @@ class CrytekMaterialExporter:
 #------------------------------------------------------------------------------
 
     def export_library_materials(self, library_materials):
-        for material, materialname in self._materials.items():
+        for material_name, material in self._materials.items():
             material_element = self._doc.createElement('material')
-            material_element.setAttribute('id', materialname)
+            material_element.setAttribute('id', material_name)
             instance_effect = self._doc.createElement('instance_effect')
-            instance_effect.setAttribute('url', '#{}_fx'.format(materialname))
+            instance_effect.setAttribute('url', '#{}_fx'.format(material_name))
             material_element.appendChild(instance_effect)
             library_materials.appendChild(material_element)

--- a/io_bcry_exporter/utils.py
+++ b/io_bcry_exporter/utils.py
@@ -480,15 +480,6 @@ def clean_file(just_selected=False):
                 for bone in object_.data.bones:
                     bone.name = replace_invalid_rc_characters(bone.name)
 
-        for material in material_utils.get_materials(just_selected):
-            material.name = replace_invalid_rc_characters(material.name)
-
-            for image in material_utils.get_textures(material):
-                try:
-                    image.name = replace_invalid_rc_characters(image.name)
-                except AttributeError:
-                    pass
-
 
 def replace_invalid_rc_characters(string):
     # Remove leading and trailing spaces.


### PR DESCRIPTION
- Reorganized material storage and exporting sequences.
- If different object have different materials named according to BCRY convention, than material sequences may be incorrect, that situation has been fixed.
- Flipped key and values for material dictionary. That will decrease code length.
- New __sort_materials_by_names__ functions has been added.
- Material exporting process is written to log screen.

![generatematerials_outputdata](https://cloud.githubusercontent.com/assets/12111733/23117829/3a9d4968-f75a-11e6-87e5-9f88e69d14e9.jpg)

![generatematerials_output](https://cloud.githubusercontent.com/assets/12111733/23117825/366290b0-f75a-11e6-9513-885bcaa2593c.jpg)