### PR TITLE
Hull UDP

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -1182,7 +1182,6 @@ class EditPhysicProxy(bpy.types.Operator):
                                     description=desc.list['no_exp_occlusion'])
     colltype_player = BoolProperty(name="Colltype Player",
                                    description=desc.list['colltpye_player'])
-    wheel = BoolProperty(name="Wheel", description="Wheel for vehicles.")
 
     object_ = None
 
@@ -1200,7 +1199,6 @@ class EditPhysicProxy(bpy.types.Operator):
             self.no_exp_occlusion)
         self.colltype_player = udp.get_udp(
             self.object_, "colltype_player", self.colltype_player)
-        self.wheel = udp.get_udp(self.object_, "wheel", self.wheel)
 
         return None
 
@@ -1224,7 +1222,6 @@ class EditPhysicProxy(bpy.types.Operator):
             "colltype_player",
             "colltype_player",
             self.colltype_player)
-        udp.edit_udp(self.object_, "wheel", "wheel", self.wheel)
 
         return {'FINISHED'}
 
@@ -1276,6 +1273,7 @@ class EditRenderMesh(bpy.types.Operator):
                                     description=desc.list['other_rendermesh'])
 
     hull = BoolProperty(name="Hull", description="Hull for vehicles.")
+    wheel = BoolProperty(name="Wheel", description="Wheel for vehicles.")
 
     object_ = None
 
@@ -1300,6 +1298,7 @@ class EditRenderMesh(bpy.types.Operator):
         self.is_dynamic = udp.get_udp(self.object_, "dynamic", self.is_dynamic)
 
         self.hull = udp.get_udp(self.object_, "hull", self.hull)
+        self.wheel = udp.get_udp(self.object_, "wheel", self.wheel)
 
         return None
 
@@ -1324,6 +1323,7 @@ class EditRenderMesh(bpy.types.Operator):
             "other_rendermesh",
             self.other_rendermesh)
         udp.edit_udp(self.object_, "hull", "hull", self.hull)
+        udp.edit_udp(self.object_, "wheel", "wheel", self.wheel)
 
         return {'FINISHED'}
 

--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -1275,6 +1275,8 @@ class EditRenderMesh(bpy.types.Operator):
     other_rendermesh = BoolProperty(name="Other Rendermesh",
                                     description=desc.list['other_rendermesh'])
 
+    hull = BoolProperty(name="Hull", description="Hull for vehicles.")
+
     object_ = None
 
     def __init__(self):
@@ -1296,6 +1298,8 @@ class EditRenderMesh(bpy.types.Operator):
 
         self.is_entity = udp.get_udp(self.object_, "entity", self.is_entity)
         self.is_dynamic = udp.get_udp(self.object_, "dynamic", self.is_dynamic)
+
+        self.hull = udp.get_udp(self.object_, "hull", self.hull)
 
         return None
 
@@ -1319,6 +1323,7 @@ class EditRenderMesh(bpy.types.Operator):
             "other_rendermesh",
             "other_rendermesh",
             self.other_rendermesh)
+        udp.edit_udp(self.object_, "hull", "hull", self.hull)
 
         return {'FINISHED'}
 

--- a/io_bcry_exporter/udp.py
+++ b/io_bcry_exporter/udp.py
@@ -91,6 +91,7 @@ def is_user_defined_property(property_name):
         "thickness",
         "explosion_scale",
         "notaprim",
+        "hull",
         "wheel"]
 
     return property_name in prop_list


### PR DESCRIPTION
- Add __hull__ UDP property to __Render Mesh Menu__ for vehicle.
- Transfer __wheel__ UDP property to __Render Mesh Menu__ from __Physic Proxy Menu__.

__Hull__
![vehicle_hull_udp](https://cloud.githubusercontent.com/assets/12111733/23155745/958eac96-f81c-11e6-8b5f-0f8bf96d0073.jpg)

__Wheel__
![vehicle_wheel_udp](https://cloud.githubusercontent.com/assets/12111733/23155760/a2534eb4-f81c-11e6-85ec-eacdbd80d5a8.jpg)

