### PR TITLE
Add Breakable Joint Window

### DIFF
--- a/io_bcry_exporter/utils.py
+++ b/io_bcry_exporter/utils.py
@@ -341,6 +341,16 @@ def check_sharp_edges(vertex, current_face, previous_face, target_face):
     return False
 
 
+def get_joint_name(object_, index=1):
+    joint_name = "$joint{:02d}".format(index)
+
+    for child in object_.children:
+        if child.name == joint_name:
+            return get_joint_name(object_, index + 1)
+
+    return joint_name
+
+
 #------------------------------------------------------------------------------
 # Path Manipulations:
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Add Breakable Joint tool has completely rewritten and added new window.

- [x] Export node control: Active object should be in a **CGF** node.
- [x] Empty object selection control: Active object should be a empty.
- [x] New auto naming function: Now joint name automatically set according to **CryEngine** reference.
- [x] UDPs for new add breakable joint window.

![add_breakable_joint](https://cloud.githubusercontent.com/assets/12111733/24287704/4a8fd1dc-1083-11e7-809e-857332224016.jpg)
