### PR TITLE
Generate LODs Icon

### DIFF
--- a/io_bcry_exporter/__init__.py
+++ b/io_bcry_exporter/__init__.py
@@ -3327,8 +3327,8 @@ class MeshUtilitiesPanel(View3DPanel, Panel):
 
         col.operator(
             "mesh.generate_lod_meshes",
-            text="Create LODs",
-            icon="EDIT_VEC")
+            text="Generate LODs",
+            icon="OOPS")
         col.separator()
 
         col.separator()
@@ -3620,7 +3620,7 @@ class MeshUtilitiesMenu(bpy.types.Menu):
         layout.operator(
             "mesh.generate_lod_meshes",
             text="Generate LODs",
-            icon="EDIT_VEC")
+            icon="OOPS")
         layout.separator()
 
         layout.label(text="Weight Repair")


### PR DESCRIPTION
__EDIT_VEC__ icon is not available with Blender 2.79. That cause the loading problem of __Mesh Utilities__.

- __EDIT_VEC__ icon has been replaced with __OOPS__ for Generate LODs tool.
- __Create LODs__ name has been changed with __Generate LODs__ for tool shelf panel.